### PR TITLE
feat: add multi-frame VLM pipeline with frame buffering and fallback

### DIFF
--- a/src/live_vlm_webui/frame_buffer.py
+++ b/src/live_vlm_webui/frame_buffer.py
@@ -1,0 +1,38 @@
+"""
+Frame buffer utilities for multi-frame VLM inference.
+"""
+
+from collections import deque
+from threading import Lock
+from typing import Deque, List
+
+from PIL import Image
+
+
+class FrameBuffer:
+    """Fixed-size frame buffer with thread-safe snapshot and clear operations."""
+
+    def __init__(self, max_size: int = 16):
+        self.max_size = max(1, int(max_size))
+        self._frames: Deque[Image.Image] = deque(maxlen=self.max_size)
+        self._lock = Lock()
+
+    def add(self, frame: Image.Image) -> int:
+        """Add a frame and return current size."""
+        with self._lock:
+            self._frames.append(frame)
+            return len(self._frames)
+
+    def snapshot(self) -> List[Image.Image]:
+        """Return a copy of buffered frames."""
+        with self._lock:
+            return list(self._frames)
+
+    def clear(self) -> None:
+        """Clear all buffered frames."""
+        with self._lock:
+            self._frames.clear()
+
+    def size(self) -> int:
+        with self._lock:
+            return len(self._frames)

--- a/src/live_vlm_webui/frame_selector.py
+++ b/src/live_vlm_webui/frame_selector.py
@@ -1,0 +1,72 @@
+"""
+Frame selection strategies for multi-frame video analysis.
+"""
+
+from typing import List
+
+import numpy as np
+from PIL import Image
+
+
+class FrameSelector:
+    """Select representative frames using interval and scene-change heuristics."""
+
+    def __init__(self, scene_change_threshold: float = 20.0):
+        self.scene_change_threshold = float(scene_change_threshold)
+
+    def select_interval(self, frames: List[Image.Image], step: int) -> List[Image.Image]:
+        """Select frames at a fixed interval."""
+        if not frames:
+            return []
+        step = max(1, int(step))
+        selected = frames[::step]
+        if selected[-1] is not frames[-1]:
+            selected.append(frames[-1])
+        return selected
+
+    def select_scene_change(self, frames: List[Image.Image]) -> List[Image.Image]:
+        """Select frames where average pixel difference crosses threshold."""
+        if not frames:
+            return []
+
+        selected: List[Image.Image] = [frames[0]]
+        prev = np.asarray(frames[0], dtype=np.float32)
+
+        for frame in frames[1:]:
+            cur = np.asarray(frame, dtype=np.float32)
+            diff_score = float(np.mean(np.abs(cur - prev)))
+            if diff_score >= self.scene_change_threshold:
+                selected.append(frame)
+                prev = cur
+
+        if selected[-1] is not frames[-1]:
+            selected.append(frames[-1])
+
+        return selected
+
+    def select_representative(
+        self, frames: List[Image.Image], target_count: int, interval_step: int
+    ) -> List[Image.Image]:
+        """
+        Combine interval and scene-change selections and cap to target_count.
+        """
+        if not frames:
+            return []
+
+        target_count = max(1, int(target_count))
+
+        interval_selected = self.select_interval(frames, interval_step)
+        scene_selected = self.select_scene_change(frames)
+
+        combined: List[Image.Image] = []
+        seen_ids = set()
+        for frame in interval_selected + scene_selected:
+            frame_id = id(frame)
+            if frame_id in seen_ids:
+                continue
+            seen_ids.add(frame_id)
+            combined.append(frame)
+            if len(combined) >= target_count:
+                break
+
+        return combined if combined else [frames[-1]]

--- a/src/live_vlm_webui/server.py
+++ b/src/live_vlm_webui/server.py
@@ -37,6 +37,7 @@ from aiortc.contrib.media import MediaRelay
 
 from .vlm_service import VLMService
 from .video_processor import VideoProcessorTrack
+from .video_vlm_pipeline import VideoVLMPipeline
 from .gpu_monitor import create_monitor
 from .rtsp_track import RTSPVideoTrack
 
@@ -54,6 +55,29 @@ websockets = set()  # Track active WebSocket connections
 gpu_monitor = None  # GPU monitoring instance
 gpu_monitor_task = None  # Background task for GPU monitoring
 rtsp_tracks = {}  # Track active RTSP streams {session_id: (rtsp_track, processor_track)}
+
+
+def create_video_vlm_pipeline(service: VLMService):
+    """
+    Create optional multi-frame pipeline from env vars.
+    Keeps backward compatibility by default (disabled unless explicitly enabled).
+    """
+    enabled = os.getenv("LIVE_VLM_ENABLE_MULTI_FRAME", "0").lower() in ("1", "true", "yes", "on")
+    if not enabled:
+        return None
+
+    try:
+        return VideoVLMPipeline(
+            vlm_service=service,
+            buffer_size=int(os.getenv("LIVE_VLM_BUFFER_SIZE", "16")),
+            trigger_size=int(os.getenv("LIVE_VLM_TRIGGER_SIZE", "4")),
+            target_frames=int(os.getenv("LIVE_VLM_TARGET_FRAMES", "4")),
+            interval_step=int(os.getenv("LIVE_VLM_INTERVAL_STEP", "1")),
+            scene_change_threshold=float(os.getenv("LIVE_VLM_SCENE_THRESHOLD", "20.0")),
+        )
+    except Exception as e:
+        logger.error(f"Failed to initialize VideoVLMPipeline, fallback to single-frame mode: {e}")
+        return None
 
 
 def is_port_available(port, host="0.0.0.0"):
@@ -513,7 +537,10 @@ async def offer(request):
             relayed_rtsp = relay.subscribe(rtsp_track)
 
             processor_track = VideoProcessorTrack(
-                relayed_rtsp, vlm_service, text_callback=broadcast_text_update
+                relayed_rtsp,
+                vlm_service,
+                text_callback=broadcast_text_update,
+                pipeline=create_video_vlm_pipeline(vlm_service),
             )
 
             # Add processor directly to peer connection
@@ -536,7 +563,10 @@ async def offer(request):
             if track.kind == "video":
                 # Create processor track with VLM service and text callback
                 processor_track = VideoProcessorTrack(
-                    relay.subscribe(track), vlm_service, text_callback=broadcast_text_update
+                    relay.subscribe(track),
+                    vlm_service,
+                    text_callback=broadcast_text_update,
+                    pipeline=create_video_vlm_pipeline(vlm_service),
                 )
 
                 # Add processed track back to connection
@@ -604,7 +634,10 @@ async def rtsp_start(request):
 
         # Create processor track (same as WebRTC path)
         processor_track = VideoProcessorTrack(
-            rtsp_track, vlm_service, text_callback=broadcast_text_update
+            rtsp_track,
+            vlm_service,
+            text_callback=broadcast_text_update,
+            pipeline=create_video_vlm_pipeline(vlm_service),
         )
 
         # Start background task to consume frames

--- a/src/live_vlm_webui/video_processor.py
+++ b/src/live_vlm_webui/video_processor.py
@@ -29,6 +29,7 @@ import time
 import av
 
 from .vlm_service import VLMService
+from .video_vlm_pipeline import VideoVLMPipeline
 
 # Enable swscaler warnings to track hardware acceleration status
 # TODO: Implement hardware-accelerated color space conversion on Jetson using NVMM/VPI
@@ -48,11 +49,18 @@ class VideoProcessorTrack(VideoStreamTrack):
     # Max allowed latency before dropping frames (in seconds, 0 = disabled)
     max_frame_latency = 0.0
 
-    def __init__(self, track: VideoStreamTrack, vlm_service: VLMService, text_callback=None):
+    def __init__(
+        self,
+        track: VideoStreamTrack,
+        vlm_service: VLMService,
+        text_callback=None,
+        pipeline: Optional[VideoVLMPipeline] = None,
+    ):
         super().__init__()
         self.track = track
         self.vlm_service = vlm_service
         self.text_callback = text_callback  # Callback to send text updates
+        self.pipeline = pipeline
         self.last_frame: Optional[np.ndarray] = None
         self.frame_count = 0
         self.dropped_frames = 0
@@ -162,7 +170,10 @@ class VideoProcessorTrack(VideoStreamTrack):
                     # Convert to PIL Image for VLM
                     pil_img = Image.fromarray(cv2.cvtColor(img, cv2.COLOR_BGR2RGB))
                     # Fire and forget - don't wait for result
-                    asyncio.create_task(self.vlm_service.process_frame(pil_img))
+                    if self.pipeline:
+                        asyncio.create_task(self.pipeline.process_frame(pil_img))
+                    else:
+                        asyncio.create_task(self.vlm_service.process_frame(pil_img))
                     logger.info(f"Frame {self.frame_count}: Sending to VLM (interval={interval})")
 
             # Get current response (may be old if VLM is still processing)

--- a/src/live_vlm_webui/video_vlm_pipeline.py
+++ b/src/live_vlm_webui/video_vlm_pipeline.py
@@ -1,0 +1,135 @@
+"""
+Multi-frame VLM pipeline with OpenAI-compatible multi-image + fallback support.
+"""
+
+import asyncio
+import base64
+import io
+import logging
+import time
+from typing import List, Optional
+
+from PIL import Image
+
+from .frame_buffer import FrameBuffer
+from .frame_selector import FrameSelector
+from .vlm_service import VLMService
+
+logger = logging.getLogger(__name__)
+
+
+class VideoVLMPipeline:
+    """Buffer frames, pick representative frames, and run multi-frame VLM inference."""
+
+    def __init__(
+        self,
+        vlm_service: VLMService,
+        buffer_size: int = 16,
+        trigger_size: int = 4,
+        target_frames: int = 4,
+        interval_step: int = 1,
+        scene_change_threshold: float = 20.0,
+    ):
+        self.vlm_service = vlm_service
+        self.buffer = FrameBuffer(max_size=buffer_size)
+        self.selector = FrameSelector(scene_change_threshold=scene_change_threshold)
+        self.trigger_size = max(1, int(trigger_size))
+        self.target_frames = max(1, int(target_frames))
+        self.interval_step = max(1, int(interval_step))
+        self._lock = asyncio.Lock()
+
+    async def process_frame(self, image: Image.Image, prompt: Optional[str] = None) -> None:
+        """Collect one frame and trigger inference when enough frames are available."""
+        current_size = self.buffer.add(image)
+        if current_size < self.trigger_size:
+            return
+
+        if self._lock.locked():
+            logger.debug("Pipeline is busy, buffering frame only")
+            return
+
+        async with self._lock:
+            frames = self.buffer.snapshot()
+            self.buffer.clear()
+            if not frames:
+                return
+
+            selected = self.selector.select_representative(
+                frames=frames, target_count=self.target_frames, interval_step=self.interval_step
+            )
+            if not selected:
+                return
+
+            self.vlm_service.is_processing = True
+            try:
+                if len(selected) == 1:
+                    result = await self.vlm_service.analyze_image(selected[0], prompt=prompt)
+                else:
+                    result = await self._analyze_multi_with_fallback(selected, prompt=prompt)
+                self.vlm_service.current_response = result
+            except Exception as e:
+                logger.error(f"VideoVLMPipeline inference failed: {e}", exc_info=True)
+                self.vlm_service.current_response = f"Error: {str(e)}"
+            finally:
+                self.vlm_service.is_processing = False
+
+    async def _analyze_multi_with_fallback(
+        self, frames: List[Image.Image], prompt: Optional[str] = None
+    ) -> str:
+        """Try multi-image request first; if unsupported, fallback to per-frame inference."""
+        try:
+            return await self._analyze_multi_image(frames, prompt=prompt)
+        except Exception as e:
+            logger.warning(
+                f"Multi-image inference failed, using single-image fallback: {e}",
+                exc_info=True,
+            )
+            results = []
+            for i, frame in enumerate(frames, start=1):
+                frame_prompt = prompt or self.vlm_service.prompt
+                frame_prompt = f"{frame_prompt}\n\nFrame {i}/{len(frames)}"
+                result = await self.vlm_service.analyze_image(frame, prompt=frame_prompt)
+                results.append(f"[Frame {i}] {result}")
+            return "\n".join(results)
+
+    async def _analyze_multi_image(self, frames: List[Image.Image], prompt: Optional[str] = None) -> str:
+        """Call OpenAI-compatible chat completion with multiple image_url entries."""
+        prompt_text = prompt or self.vlm_service.prompt
+
+        content = [{"type": "text", "text": prompt_text}]
+        for frame in frames:
+            content.append(
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/jpeg;base64,{self._to_base64(frame)}"},
+                }
+            )
+
+        messages = [{"role": "user", "content": content}]
+
+        start_time = time.perf_counter()
+        response = await self.vlm_service.client.chat.completions.create(
+            model=self.vlm_service.model,
+            messages=messages,
+            max_tokens=self.vlm_service.max_tokens,
+            temperature=0.7,
+        )
+        elapsed = time.perf_counter() - start_time
+
+        self.vlm_service.last_inference_time = elapsed
+        self.vlm_service.total_inferences += 1
+        self.vlm_service.total_inference_time += elapsed
+
+        result = (response.choices[0].message.content or "").strip()
+        logger.info(
+            f"Multi-frame VLM response generated from {len(frames)} frames "
+            f"(latency: {elapsed*1000:.0f}ms)"
+        )
+        return result
+
+    @staticmethod
+    def _to_base64(image: Image.Image) -> str:
+        """Convert PIL image to base64-encoded JPEG."""
+        buff = io.BytesIO()
+        image.save(buff, format="JPEG")
+        return base64.b64encode(buff.getvalue()).decode("utf-8")


### PR DESCRIPTION
## Summary
- add multi-frame inference components:
- `src/live_vlm_webui/frame_buffer.py`
- `src/live_vlm_webui/frame_selector.py`
- `src/live_vlm_webui/video_vlm_pipeline.py`
- wire pipeline into existing processing path:
- `src/live_vlm_webui/video_processor.py`
- `src/live_vlm_webui/server.py`
- keep backward compatibility:
- legacy single-frame mode is preserved
- multi-frame mode is enabled only when `LIVE_VLM_ENABLE_MULTI_FRAME=1`

## Behavior Changes
- Legacy mode (`LIVE_VLM_ENABLE_MULTI_FRAME` unset/0):
- unchanged behavior (`vlm_service.process_frame(...)`)
- Multi-frame mode (`LIVE_VLM_ENABLE_MULTI_FRAME=1`):
- frame buffering -> representative frame selection -> multi-image inference
- fallback to per-frame inference if multi-image request is unsupported

## Config (Multi-frame)
- `LIVE_VLM_ENABLE_MULTI_FRAME`
- `LIVE_VLM_BUFFER_SIZE`
- `LIVE_VLM_TRIGGER_SIZE`
- `LIVE_VLM_TARGET_FRAMES`
- `LIVE_VLM_INTERVAL_STEP`
- `LIVE_VLM_SCENE_THRESHOLD`

## Validation
- syntax check passed for modified/new files:
- `video_processor.py`
- `server.py`
- `frame_buffer.py`
- `frame_selector.py`
- `video_vlm_pipeline.py`

## Notes
- UI (`src/live_vlm_webui/static/index.html`) is not modified.
- This PR focuses on minimal-diff backend extension.
