### PR TITLE
feat: dispatch webhook events on single-frame inference completion

### DIFF
--- a/src/live_vlm_webui/server.py
+++ b/src/live_vlm_webui/server.py
@@ -38,6 +38,7 @@ from aiortc.contrib.media import MediaRelay
 from .vlm_service import VLMService
 from .video_processor import VideoProcessorTrack
 from .video_vlm_pipeline import VideoVLMPipeline
+from .event_dispatcher import EventDispatcher, EventDispatcherConfig
 from .gpu_monitor import create_monitor
 from .rtsp_track import RTSPVideoTrack
 
@@ -795,7 +796,7 @@ async def on_startup(app):
 
 async def on_shutdown(app):
     """Cleanup on server shutdown"""
-    global gpu_monitor, gpu_monitor_task
+    global gpu_monitor, gpu_monitor_task, vlm_service
 
     logger.info("Shutting down server...")
 
@@ -827,6 +828,14 @@ async def on_shutdown(app):
     coros = [pc.close() for pc in pcs]
     await asyncio.gather(*coros)
     pcs.clear()
+
+    # Close optional webhook dispatcher session if present
+    if vlm_service and getattr(vlm_service, "event_dispatcher", None):
+        try:
+            await vlm_service.event_dispatcher.close()
+            logger.info("Webhook dispatcher closed")
+        except Exception as e:
+            logger.warning(f"Failed to close webhook dispatcher: {e}")
 
     logger.info("Cleanup complete")
 
@@ -1065,9 +1074,30 @@ def main():
                 logger.warning("   Set with: --api-key YOUR_API_KEY")
                 logger.warning("   Or use WebUI to configure API settings after starting")
 
+    # Build optional event dispatcher (Issue 3: single-frame inference dispatch wiring)
+    event_dispatcher = None
+    if webhook_config.enabled:
+        event_dispatcher = EventDispatcher(
+            EventDispatcherConfig(
+                enabled=webhook_config.enabled,
+                url=webhook_config.url,
+                timeout_sec=webhook_config.timeout_sec,
+                mode=webhook_config.mode,
+                sample_every=webhook_config.sample_every,
+                include_metrics=webhook_config.include_metrics,
+            )
+        )
+        logger.info("Webhook dispatcher initialized")
+
     # Initialize VLM service
     global vlm_service
-    vlm_service = VLMService(model=model, api_base=api_base, api_key=api_key, prompt=args.prompt)
+    vlm_service = VLMService(
+        model=model,
+        api_base=api_base,
+        api_key=api_key,
+        prompt=args.prompt,
+        event_dispatcher=event_dispatcher,
+    )
 
     # Log initialization with better formatting
     service_name = "Local" if "localhost" in api_base or "127.0.0.1" in api_base else "Cloud"

--- a/src/live_vlm_webui/vlm_service.py
+++ b/src/live_vlm_webui/vlm_service.py
@@ -25,8 +25,10 @@ import io
 import time
 from openai import AsyncOpenAI
 from PIL import Image
-from typing import Optional
+from typing import Optional, Any
 import logging
+
+from .event_dispatcher import EventDispatcher
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +43,7 @@ class VLMService:
         api_key: str = "EMPTY",
         prompt: str = "Describe what you see in this image in one sentence.",
         max_tokens: int = 512,
+        event_dispatcher: Optional[EventDispatcher] = None,
     ):
         """
         Initialize VLM service
@@ -58,6 +61,7 @@ class VLMService:
         self.prompt = prompt
         self.max_tokens = max_tokens
         self.client = AsyncOpenAI(base_url=api_base, api_key=api_key)
+        self.event_dispatcher = event_dispatcher
         self.current_response = "Initializing..."
         self.is_processing = False
         self._processing_lock = asyncio.Lock()
@@ -145,8 +149,31 @@ class VLMService:
             try:
                 response = await self.analyze_image(image, prompt)
                 self.current_response = response
+                await self._dispatch_single_inference_event(response)
             finally:
                 self.is_processing = False
+
+    async def _dispatch_single_inference_event(self, response: str) -> None:
+        """
+        Dispatch single-frame inference event if dispatcher is configured.
+        Failures are intentionally non-fatal.
+        """
+        if not self.event_dispatcher:
+            return
+
+        payload: dict[str, Any] = {
+            "mode": "single",
+            "text": response,
+            "model": self.model,
+            "api_base": self.api_base,
+        }
+        if self.event_dispatcher.config.include_metrics:
+            payload["metrics"] = self.get_metrics()
+
+        try:
+            await self.event_dispatcher.dispatch(payload, mode="single")
+        except Exception as e:
+            logger.error("Unexpected webhook dispatch error in single mode: %s", e)
 
     def get_current_response(self) -> tuple[str, bool]:
         """


### PR DESCRIPTION
  ## Summary
  - wire webhook dispatch into single-frame inference completion path
  - keep existing realtime VLM behavior unchanged when webhook is disabled
  - add safe lifecycle handling for dispatcher shutdown

  ## Changes
  - `src/live_vlm_webui/vlm_service.py`
    - add optional `event_dispatcher` dependency to `VLMService`
    - dispatch event after successful single-frame inference completion
    - include payload fields: `mode`, `text`, `model`, `api_base` (+ `metrics` when enabled)
    - keep dispatch failures non-fatal (log only)

  - `src/live_vlm_webui/server.py`
    - initialize `EventDispatcher` from loaded webhook config
    - inject dispatcher into `VLMService`
    - close dispatcher session during server shutdown

  ## Backward Compatibility
  - webhook remains optional and config-driven
  - if webhook is disabled or unset, behavior is unchanged from existing flow
  - VLM inference and WebSocket updates continue even when webhook delivery fails

  ## Validation
  - syntax check passed:
    - `python -m py_compile src/live_vlm_webui/vlm_service.py src/live_vlm_webui/server.py`

  ## Notes
  - this PR targets single-frame path only (`mode=single`)
  - multi-frame dispatch wiring is intentionally out of scope and planned separately

  Closes h-nakagawa-ykc/live-vlm-webui#6
