### PR TITLE
feat: improve live-vlm runtime flow for server and rtsp track

### DIFF
--- a/src/live_vlm_webui/rtsp_track.py
+++ b/src/live_vlm_webui/rtsp_track.py
@@ -95,7 +95,13 @@ class RTSPVideoTrack(VideoStreamTrack):
             logger.info(f"Connecting to RTSP stream: {safe_url}")
 
             # Open RTSP stream
-            self.container = av.open(self.rtsp_url, options=self.options)
+            # self.container = av.open(self.rtsp_url, options=self.options)
+            try:
+                self.container = av.open(self.rtsp_url, options=self.options)
+            except Exception as e:
+                logger.error(f"Failed to connect to RTSP stream {safe_url}: {e} -> rtsp_transport is UDP retry...")
+                self.options["rtsp_transport"] = "udp"
+                self.container = av.open(self.rtsp_url, options=self.options)
 
             # Get video stream
             if not self.container.streams.video:


### PR DESCRIPTION
  ## 概要
  `live-vlm-webui` の実行時の挙動改善として、`rtsp_track.py` を更新。

  ## 目的
  - 実行時安定性・運用性の向上
  - 既存フローで発生していた不整合/扱いづらさの改善
  - 具体的には、入力ソースとしてVLC Media PlayerからRTSP配信を指定した場合を想定した修正
    - VLCの送信プロトコルがUDPになっており、RTSP接続が確立できない
    - webカメラ仕様時のwebRTC接続や、ネットワークカメラ使用時のRTSP接続の場合、同様のエラーは発生しない（送信プロトコルがTCPになっているためと推測）

  ## 変更内容
  - `src/live_vlm_webui/rtsp_track.py` を更新
  - PyAVモジュールでRTSPをOPENする際（デフォルトはTCP想定）、例外発生時に、UDPで、再度OPENを試行する
 
  ## 影響範囲
  - サーバ起動・RTSP入力系の挙動

  ## 確認内容
  - 既存の起動フローで問題なく動作すること
  - RTSP関連の基本動作確認

  ## リスク/留意点
  - 実行時入力ソース関連の部分であるため、デモ前に実機確認を実施推奨