### PR TITLE
fix: follow up webhook payload v1.1 server changes omitted in #22

### DIFF
--- a/src/live_vlm_webui/server.py
+++ b/src/live_vlm_webui/server.py
@@ -1132,7 +1132,6 @@ def main():
     protocol = "http"
     if not args.no_ssl:
         # Try to auto-generate if certificates don't exist
-        import os
         import sys
 
         if not os.path.exists(args.ssl_cert) or not os.path.exists(args.ssl_key):


### PR DESCRIPTION
  ## 概要
  This PR is a follow-up for #22
  `server.py` 変更が #22 から漏れていたため補完

  ## 目的
  - ローカル実行時に発生した以下エラーの対処
  ```
  ==========
  == CUDA ==
  ==========

  CUDA Version 12.4.1

  Container image Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.

  This container image and its contents are governed by the NVIDIA Deep Learning Container License.
  By pulling and using the container, you accept the terms and conditions of this license:
  https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license

  A copy of this license is made available in this container at /NGC-DL-CONTAINER-LICENSE for your convenience.

  WARNING: The NVIDIA Driver was not detected.  GPU functionality will not be available.
     Use the NVIDIA Container Toolkit to start this container with GPU support; see
     https://docs.nvidia.com/datacenter/cloud-native/ .

  /usr/lib/python3.10/runpy.py:126: RuntimeWarning: 'live_vlm_webui.server' found in sys.modules after import of package 'live_vlm_webui', but prior to execution of 'live_vlm_webui.server'; this may
  result in unpredictable behaviour
    warn(RuntimeWarning(msg))
  2026-03-06 10:57:48,980 - __main__ - INFO - Webhook config:
  2026-03-06 10:57:48,980 - __main__ - INFO -   Enabled: True
  2026-03-06 10:57:48,980 - __main__ - INFO -   URL configured: True
  2026-03-06 10:57:48,980 - __main__ - INFO -   Timeout: 1.00s
  2026-03-06 10:57:48,981 - __main__ - INFO -   Mode: both
  2026-03-06 10:57:48,981 - __main__ - INFO -   Sample every: 1
  2026-03-06 10:57:48,981 - __main__ - INFO -   Include metrics: True
  2026-03-06 10:57:48,981 - __main__ - INFO - No model/API specified, auto-detecting local services...
  2026-03-06 10:57:48,983 - __main__ - INFO - ✅ Auto-detected Ollama at http://localhost:11434/v1
  2026-03-06 10:57:48,983 - __main__ - INFO -    Selected model: gemma3:4b (vision model preferred but not found)
  2026-03-06 10:57:48,984 - __main__ - INFO - Webhook dispatcher initialized
  Traceback (most recent call last):
    File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
      return _run_code(code, main_globals, None,
    File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
      exec(code, run_globals)
    File "/app/src/live_vlm_webui/server.py", line 1305, in <module>
      main()
    File "/app/src/live_vlm_webui/server.py", line 1102, in main
      camera_id = os.getenv("LIVE_VLM_CAMERA_ID", "").strip()
  UnboundLocalError: local variable 'os' referenced before assignment
  ```

  ## 変更内容
  - `src/live_vlm_webui/server.py` を更新
  - `main()` の中に後半で import os があり、Pythonが os をローカル変数扱いして冒頭参照時に UnboundLocalError発生
  - 今回の UnboundLocalError は、main() 内の import os（1135行目）があることで、os が main() のローカル変数扱いになり、1102行目の os.getenv(...) 時点で未初期化参照になることが原因

  ## 影響範囲
  

  ## 確認内容
  - ローカル環境にて動作確認