### PR TITLE
docs: add MVP demo explanatory document and diagrams

### DIFF
--- a/MVP_DEMO_EXPLANATORY_DOC.md
+++ b/MVP_DEMO_EXPLANATORY_DOC.md
@@ -1,0 +1,201 @@
+# live-vlm-webui 改修版: MVPデモ説明資料（Webhook連携）
+
+## 1. この資料の目的
+この資料は、`live-vlm-webui` フォーク改修版における以下を、**現状ソースコード準拠**で説明するためのものです。
+- 何を追加したか（マルチフレーム推論 + Webhook連携）
+- MVPデモで何を見せるか（VLM結果を外部アクションに接続）
+- 現在の実装状態と、今後の拡張ロードマップ
+
+対象リポジトリ: `./live-vlm-webui`
+
+---
+
+## 2. 全体像（実装済み）
+
+### 2.1 追加済みの主要機能
+- マルチフレーム推論パイプライン
+  - `src/live_vlm_webui/frame_buffer.py`
+  - `src/live_vlm_webui/frame_selector.py`
+  - `src/live_vlm_webui/video_vlm_pipeline.py`
+- Webhook送信機能（VLM推論結果の非同期通知）
+  - `src/live_vlm_webui/event_dispatcher.py`
+  - `src/live_vlm_webui/webhook_config.py`
+  - `src/live_vlm_webui/vlm_service.py`
+- Webhook受信サーバー（action-webhook）
+  - `services/action-webhook/main.py`
+  - `services/action-webhook/rules.py`
+  - `services/action-webhook/actions/slack.py`
+  - `services/action-webhook/actions/device_http.py`
+  - `services/action-webhook/rule_configs/rules.yaml`
+
+### 2.2 動作モード
+- 単一フレーム推論（従来互換）
+- マルチフレーム推論（環境変数で有効化時のみ）
+- Webhook送信（環境変数で有効化時のみ）
+
+---
+
+## 3. システム構成（MVPデモ想定）
+
+### 3.1 データフロー
+1. カメラ入力（WebRTC または RTSP）
+2. `VideoProcessorTrack` がフレームを間引いて推論経路へ投入
+3. 推論経路
+   - Single: `VLMService.process_frame()`
+   - Multi: `VideoVLMPipeline.process_frame()`
+4. 推論結果を WebUI へ反映（WebSocket）
+5. 同時に Webhook payload を `POST /events` 送信
+6. `action-webhook` がルール評価
+7. 条件一致で Slack通知 / HTTP機器制御 を実行
+
+### 3.2 コンテナ構成（docker-compose）
+`docker/docker-compose.override.yml` では、以下連携を前提に構成済み。
+- `live-vlm-webui`（送信側）
+- `action-webhook`（受信側、`8081`）
+- `ollama` / `nim` などVLMバックエンド（profile選択）
+
+---
+
+## 4. 送信payload仕様（v1.1）
+参照: `docs/development/webhook-events.md`
+
+### 4.1 主要フィールド
+- 必須: `event_id`, `event_type`, `timestamp_unix`, `mode`, `text`, `model`, `api_base`
+- 任意:
+  - `metrics`
+  - `risk_score`, `labels`
+  - `camera_id`, `stream_id`, `inference_prompt_id`
+  - （multi時）`selected_frame_count`, `buffered_frame_count`, `used_fallback`
+
+### 4.2 後方互換方針
+- unknown field は受信側で無視
+- v1.xで既存項目の意味は維持
+
+---
+
+## 5. action-webhook の判定・実行ロジック
+
+### 5.1 受信API
+- `GET /healthz`
+- `POST /events`
+
+### 5.2 ルール評価（`RuleEvaluator`）
+現在のデフォルトルール:
+- `rule_yes`: answer=yes -> `slack + device`
+- `rule_no`: answer=no -> `slack`
+- `rule_keyword_alert`: textに `ALERT|WARNING|CAUTION` -> `slack`
+- `rule_risk_high`: `risk_score >= threshold` -> `slack`
+
+### 5.3 実行アクション
+- Slack Incoming Webhook送信
+- HTTP POST による機器連携
+- 失敗しても `/events` 自体は受理継続（非致命設計）
+
+---
+
+## 6. MVPデモで見せる内容（推奨）
+
+### 6.1 デモ観点
+- 観点A: 推論結果のリアルタイム可視化（WebUI）
+- 観点B: 推論結果の外部通知（Webhook -> Slack）
+- 観点C: 推論結果の外部制御（Webhook -> Device HTTP）
+
+### 6.2 推奨シナリオ
+1. Yes/No判定
+- `yes` で Slack + Device
+- `no` で Slackのみ
+
+2. 危険キーワード判定
+- `ALERT` / `WARNING` / `CAUTION` を含む応答で通知
+
+3. risk_score判定
+- `risk_score >= RISK_THRESHOLD` で通知
+
+---
+
+## 7. 実行設定（環境変数）
+
+### 7.1 送信側（live-vlm-webui）
+- `LIVE_VLM_ENABLE_MULTI_FRAME`
+- `LIVE_VLM_WEBHOOK_ENABLED`
+- `LIVE_VLM_WEBHOOK_URL`
+- `LIVE_VLM_WEBHOOK_MODE`
+- `LIVE_VLM_WEBHOOK_SAMPLE_EVERY`
+- `LIVE_VLM_WEBHOOK_INCLUDE_METRICS`
+- `LIVE_VLM_CAMERA_ID`, `LIVE_VLM_STREAM_ID`, `LIVE_VLM_INFERENCE_PROMPT_ID`
+
+### 7.2 受信側（action-webhook）
+- `ACTION_RULES_ENABLED`
+- `ACTION_RULES_FILE`
+- `RISK_THRESHOLD`
+- `SLACK_WEBHOOK_URL`
+- `DEVICE_ENDPOINT_URL`
+- `DEVICE_TIMEOUT_SEC`
+
+---
+
+## 8. Dockerテスト結果（2026-03-12 実行）
+実行スクリプト:
+- `scripts/run_ci_tests_docker.sh`
+
+実行対象:
+- `tests/unit/test_event_dispatcher.py`
+- `tests/unit/test_vlm_service_webhook_resilience.py`
+- `tests/unit/test_action_webhook_rules.py`
+- `tests/unit/test_webhook_payload_v11.py`
+- `tests/integration/test_action_webhook_integration.py`
+
+結果サマリ:
+- 9 passed
+- 2 failed
+- 3 skipped
+
+失敗テスト:
+- `test_risk_rule_triggers_slack_with_payload_field`
+- `test_multiple_rule_matches_dedupe_actions`
+
+示唆:
+- `services/action-webhook/rules.py` の `risk_score` 抽出実装と、テスト期待（payload直値 `risk_score` の評価）に不整合がある可能性
+
+スキップ:
+- integration 3件は、`fastapi` モジュール解決条件により skip
+
+---
+
+## 9. 現状評価（MVP観点）
+
+### 9.1 できていること
+- WebUIの推論処理を壊さず、Webhook送信を非同期で追加
+- 単一/複数フレームの両経路からpayload送信
+- 受信側でルール評価し、通知/外部POSTまで到達可能な骨格実装
+- ルール外部化（YAML）への移行方針が既に実装に反映
+
+### 9.2 残課題（デモ前に詰めるべき点）
+- `risk_score` 判定の実装・テスト整合性修正
+- integration test の実行前提（fastapi）をDocker環境で安定化
+- 実Slack/実機器エンドポイントへの手動疎通確認（最終スモーク）
+
+---
+
+## 10. ロードマップ位置づけ
+参照: `docs/development/action-orchestration-roadmap-ja.md`
+
+- Phase 1（MVP）
+  - 受信 -> 判定 -> Slack/Device 実行まで
+- Phase 2
+  - payload v1.1運用の安定化（risk_score活用）
+- Phase 3
+  - ルール高度化（外部定義、複合条件、抑制/監査）
+- 将来
+  - MQTT / ROS2 / Physical AI 連携
+
+---
+
+## 11. 関連ドキュメント
+- `README_MODIFY.md`
+- `docs/development/webhook-events.md`
+- `docs/development/action-orchestration-roadmap-ja.md`
+- `docs/development/action-webhook-manual-test-ja.md`
+- `docs/development/action-webhook-integration-test-cases-ja.md`
+- `services/action-webhook/README.md`
+

--- a/mvp_demo_svgs/slide01_title.svg
+++ b/mvp_demo_svgs/slide01_title.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1f3a"/>
+      <stop offset="100%" stop-color="#173a5e"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <rect x="90" y="90" width="1420" height="720" rx="20" fill="#ffffff" opacity="0.08"/>
+  <text x="120" y="210" font-family="Noto Sans CJK JP, sans-serif" font-size="58" fill="#ffffff" font-weight="700">live-vlm-webui 改修版</text>
+  <text x="120" y="290" font-family="Noto Sans CJK JP, sans-serif" font-size="58" fill="#8be9fd" font-weight="700">MVPデモ資料: Webhook連携とAction Orchestration</text>
+  <text x="120" y="390" font-family="Noto Sans CJK JP, sans-serif" font-size="34" fill="#d7f3ff">目的: VLM推論結果をリアルタイムで外部通知/外部制御へ接続する</text>
+
+  <rect x="120" y="470" width="1360" height="270" rx="16" fill="#0f2f4f" opacity="0.65"/>
+  <text x="160" y="540" font-family="Noto Sans CJK JP, sans-serif" font-size="34" fill="#ffffff" font-weight="700">このデックで説明する内容</text>
+  <text x="180" y="600" font-family="Noto Sans CJK JP, sans-serif" font-size="30" fill="#d4ecff">1. 現状実装の構成（single/multi推論 + webhook送信 + 受信サーバー）</text>
+  <text x="180" y="650" font-family="Noto Sans CJK JP, sans-serif" font-size="30" fill="#d4ecff">2. MVPデモの実演フロー（検知 -> 判定 -> Slack/Device）</text>
+  <text x="180" y="700" font-family="Noto Sans CJK JP, sans-serif" font-size="30" fill="#d4ecff">3. 現状の検証結果と次フェーズの開発ロードマップ</text>
+
+  <text x="120" y="840" font-family="Noto Sans CJK JP, sans-serif" font-size="24" fill="#c2dff2">Generated for: ./live-vlm-webui  |  Date: 2026-03-12</text>
+</svg>

--- a/mvp_demo_svgs/slide02_architecture.svg
+++ b/mvp_demo_svgs/slide02_architecture.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900">
+  <rect width="1600" height="900" fill="#f6f9fc"/>
+  <text x="70" y="90" font-family="Noto Sans CJK JP, sans-serif" font-size="48" fill="#133b5c" font-weight="700">全体アーキテクチャ（現状実装）</text>
+
+  <rect x="80" y="150" width="420" height="250" rx="16" fill="#d6ecff" stroke="#3f83c7" stroke-width="3"/>
+  <text x="110" y="210" font-family="Noto Sans CJK JP, sans-serif" font-size="30" fill="#0f4e7a" font-weight="700">Input</text>
+  <text x="110" y="260" font-family="Noto Sans CJK JP, sans-serif" font-size="28" fill="#123a57">- WebRTC Camera</text>
+  <text x="110" y="305" font-family="Noto Sans CJK JP, sans-serif" font-size="28" fill="#123a57">- RTSP Stream</text>
+  <text x="110" y="350" font-family="Noto Sans CJK JP, sans-serif" font-size="24" fill="#1b5f8f">server.py / video_processor.py</text>
+
+  <rect x="560" y="150" width="460" height="300" rx="16" fill="#e4f7e8" stroke="#42a35c" stroke-width="3"/>
+  <text x="590" y="210" font-family="Noto Sans CJK JP, sans-serif" font-size="30" fill="#1f6d36" font-weight="700">Inference Core</text>
+  <text x="590" y="260" font-family="Noto Sans CJK JP, sans-serif" font-size="27" fill="#1f5b31">- Single: VLMService</text>
+  <text x="590" y="305" font-family="Noto Sans CJK JP, sans-serif" font-size="27" fill="#1f5b31">- Multi: VideoVLMPipeline</text>
+  <text x="590" y="350" font-family="Noto Sans CJK JP, sans-serif" font-size="27" fill="#1f5b31">  FrameBuffer + FrameSelector</text>
+  <text x="590" y="400" font-family="Noto Sans CJK JP, sans-serif" font-size="24" fill="#2e7f44">src/live_vlm_webui/*.py</text>
+
+  <rect x="1080" y="150" width="440" height="300" rx="16" fill="#fff5d7" stroke="#c59226" stroke-width="3"/>
+  <text x="1110" y="210" font-family="Noto Sans CJK JP, sans-serif" font-size="30" fill="#8a5a00" font-weight="700">Webhook / Action</text>
+  <text x="1110" y="260" font-family="Noto Sans CJK JP, sans-serif" font-size="27" fill="#7a4f00">- EventDispatcher (送信)</text>
+  <text x="1110" y="305" font-family="Noto Sans CJK JP, sans-serif" font-size="27" fill="#7a4f00">- action-webhook (受信)</text>
+  <text x="1110" y="350" font-family="Noto Sans CJK JP, sans-serif" font-size="27" fill="#7a4f00">- Slack / Device HTTP</text>
+  <text x="1110" y="400" font-family="Noto Sans CJK JP, sans-serif" font-size="24" fill="#8e640e">services/action-webhook/*</text>
+
+  <rect x="80" y="520" width="1440" height="280" rx="16" fill="#ffffff" stroke="#d0d9e3" stroke-width="2"/>
+  <text x="120" y="585" font-family="Noto Sans CJK JP, sans-serif" font-size="33" fill="#2b3f55" font-weight="700">実装上のポイント</text>
+  <text x="130" y="640" font-family="Noto Sans CJK JP, sans-serif" font-size="28" fill="#33495f">- 既定では従来互換（single推論）。環境変数でmulti/webhookを有効化</text>
+  <text x="130" y="690" font-family="Noto Sans CJK JP, sans-serif" font-size="28" fill="#33495f">- Webhook失敗は非致命（推論・UI更新は継続）</text>
+  <text x="130" y="740" font-family="Noto Sans CJK JP, sans-serif" font-size="28" fill="#33495f">- payload v1.1で risk_score / labels / camera_id 等を拡張</text>
+
+  <line x1="500" y1="275" x2="560" y2="275" stroke="#355a7a" stroke-width="4"/>
+  <polygon points="560,275 545,266 545,284" fill="#355a7a"/>
+  <line x1="1020" y1="300" x2="1080" y2="300" stroke="#355a7a" stroke-width="4"/>
+  <polygon points="1080,300 1065,291 1065,309" fill="#355a7a"/>
+</svg>

--- a/mvp_demo_svgs/slide03_flow.svg
+++ b/mvp_demo_svgs/slide03_flow.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900">
+  <rect width="1600" height="900" fill="#fffefb"/>
+  <text x="60" y="90" font-family="Noto Sans CJK JP, sans-serif" font-size="48" fill="#5a3e1b" font-weight="700">推論からWebhook通知までの時系列フロー</text>
+
+  <rect x="90" y="150" width="1420" height="650" rx="18" fill="#fff" stroke="#e1d3bc" stroke-width="3"/>
+
+  <circle cx="170" cy="240" r="36" fill="#f4b183"/><text x="155" y="252" font-family="Noto Sans CJK JP, sans-serif" font-size="28" fill="#fff" font-weight="700">1</text>
+  <text x="235" y="252" font-family="Noto Sans CJK JP, sans-serif" font-size="31" fill="#6b4620">カメラフレーム受信（WebRTC/RTSP）</text>
+
+  <circle cx="170" cy="330" r="36" fill="#f4b183"/><text x="155" y="342" font-family="Noto Sans CJK JP, sans-serif" font-size="28" fill="#fff" font-weight="700">2</text>
+  <text x="235" y="342" font-family="Noto Sans CJK JP, sans-serif" font-size="31" fill="#6b4620">process_every間隔で推論投入（single または multi）</text>
+
+  <circle cx="170" cy="420" r="36" fill="#f4b183"/><text x="155" y="432" font-family="Noto Sans CJK JP, sans-serif" font-size="28" fill="#fff" font-weight="700">3</text>
+  <text x="235" y="432" font-family="Noto Sans CJK JP, sans-serif" font-size="31" fill="#6b4620">VLM応答生成（text） + 構造化情報抽出（risk_score, labels）</text>
+
+  <circle cx="170" cy="510" r="36" fill="#f4b183"/><text x="155" y="522" font-family="Noto Sans CJK JP, sans-serif" font-size="28" fill="#fff" font-weight="700">4</text>
+  <text x="235" y="522" font-family="Noto Sans CJK JP, sans-serif" font-size="31" fill="#6b4620">UIへWebSocket配信 + Webhook payload組み立て（v1.1）</text>
+
+  <circle cx="170" cy="600" r="36" fill="#f4b183"/><text x="155" y="612" font-family="Noto Sans CJK JP, sans-serif" font-size="28" fill="#fff" font-weight="700">5</text>
+  <text x="235" y="612" font-family="Noto Sans CJK JP, sans-serif" font-size="31" fill="#6b4620">action-webhookで受信、ルール評価、Slack/Device実行</text>
+
+  <circle cx="170" cy="690" r="36" fill="#f4b183"/><text x="155" y="702" font-family="Noto Sans CJK JP, sans-serif" font-size="28" fill="#fff" font-weight="700">6</text>
+  <text x="235" y="702" font-family="Noto Sans CJK JP, sans-serif" font-size="31" fill="#6b4620">通知失敗時も推論処理は継続（MVPの非機能要件）</text>
+
+  <line x1="170" y1="276" x2="170" y2="294" stroke="#b97f44" stroke-width="5"/>
+  <line x1="170" y1="366" x2="170" y2="384" stroke="#b97f44" stroke-width="5"/>
+  <line x1="170" y1="456" x2="170" y2="474" stroke="#b97f44" stroke-width="5"/>
+  <line x1="170" y1="546" x2="170" y2="564" stroke="#b97f44" stroke-width="5"/>
+  <line x1="170" y1="636" x2="170" y2="654" stroke="#b97f44" stroke-width="5"/>
+</svg>

--- a/mvp_demo_svgs/slide04_rules.svg
+++ b/mvp_demo_svgs/slide04_rules.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900">
+  <rect width="1600" height="900" fill="#f4f8ff"/>
+  <text x="60" y="92" font-family="Noto Sans CJK JP, sans-serif" font-size="48" fill="#163a70" font-weight="700">action-webhook のルール判定とアクション</text>
+
+  <rect x="70" y="150" width="720" height="700" rx="20" fill="#ffffff" stroke="#c5d8f3" stroke-width="3"/>
+  <text x="110" y="215" font-family="Noto Sans CJK JP, sans-serif" font-size="34" fill="#24508c" font-weight="700">デフォルトルール</text>
+
+  <rect x="110" y="255" width="640" height="110" rx="12" fill="#e9f3ff"/>
+  <text x="130" y="305" font-family="Noto Sans CJK JP, sans-serif" font-size="29" fill="#1d467e">Rule YES: answer=yes -> slack + device</text>
+  <text x="130" y="342" font-family="Noto Sans CJK JP, sans-serif" font-size="24" fill="#345f93">rule_id: rule_yes</text>
+
+  <rect x="110" y="385" width="640" height="110" rx="12" fill="#e9f3ff"/>
+  <text x="130" y="435" font-family="Noto Sans CJK JP, sans-serif" font-size="29" fill="#1d467e">Rule NO: answer=no -> slack</text>
+  <text x="130" y="472" font-family="Noto Sans CJK JP, sans-serif" font-size="24" fill="#345f93">rule_id: rule_no</text>
+
+  <rect x="110" y="515" width="640" height="110" rx="12" fill="#e9f3ff"/>
+  <text x="130" y="565" font-family="Noto Sans CJK JP, sans-serif" font-size="29" fill="#1d467e">Rule KEYWORD: ALERT/WARNING/CAUTION -> slack</text>
+  <text x="130" y="602" font-family="Noto Sans CJK JP, sans-serif" font-size="24" fill="#345f93">rule_id: rule_keyword_alert</text>
+
+  <rect x="110" y="645" width="640" height="110" rx="12" fill="#e9f3ff"/>
+  <text x="130" y="695" font-family="Noto Sans CJK JP, sans-serif" font-size="29" fill="#1d467e">Rule RISK: risk_score >= threshold -> slack</text>
+  <text x="130" y="732" font-family="Noto Sans CJK JP, sans-serif" font-size="24" fill="#345f93">rule_id: rule_risk_high</text>
+
+  <rect x="830" y="150" width="700" height="700" rx="20" fill="#ffffff" stroke="#d9d2f0" stroke-width="3"/>
+  <text x="870" y="215" font-family="Noto Sans CJK JP, sans-serif" font-size="34" fill="#4b3a8c" font-weight="700">検証ステータス（Docker実行）</text>
+
+  <text x="870" y="285" font-family="Noto Sans CJK JP, sans-serif" font-size="30" fill="#334">- 対象: webhook関連 unit/integration</text>
+  <text x="870" y="335" font-family="Noto Sans CJK JP, sans-serif" font-size="30" fill="#334">- 結果: 9 passed / 2 failed / 3 skipped</text>
+
+  <rect x="870" y="380" width="620" height="170" rx="12" fill="#fff1f1" stroke="#d58b8b" stroke-width="2"/>
+  <text x="900" y="435" font-family="Noto Sans CJK JP, sans-serif" font-size="28" fill="#8b2a2a" font-weight="700">要対応ギャップ</text>
+  <text x="900" y="482" font-family="Noto Sans CJK JP, sans-serif" font-size="27" fill="#7b2c2c">risk_score を payload直値で評価する期待と</text>
+  <text x="900" y="524" font-family="Noto Sans CJK JP, sans-serif" font-size="27" fill="#7b2c2c">rules.py 実装の抽出ロジックに不整合</text>
+
+  <rect x="870" y="580" width="620" height="220" rx="12" fill="#f0fff1" stroke="#7fb88b" stroke-width="2"/>
+  <text x="900" y="636" font-family="Noto Sans CJK JP, sans-serif" font-size="28" fill="#2e6b3a" font-weight="700">MVPデモ運用への影響</text>
+  <text x="900" y="682" font-family="Noto Sans CJK JP, sans-serif" font-size="26" fill="#2f5f38">- yes/no と keyword ルートは動作確認済み</text>
+  <text x="900" y="724" font-family="Noto Sans CJK JP, sans-serif" font-size="26" fill="#2f5f38">- risk_score 判定の修正をデモ前に実施推奨</text>
+  <text x="900" y="766" font-family="Noto Sans CJK JP, sans-serif" font-size="26" fill="#2f5f38">- 非致命設計のため本体推論は継続可能</text>
+</svg>

--- a/mvp_demo_svgs/slide05_demo.svg
+++ b/mvp_demo_svgs/slide05_demo.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900">
+  <rect width="1600" height="900" fill="#fffaf3"/>
+  <text x="60" y="90" font-family="Noto Sans CJK JP, sans-serif" font-size="48" fill="#7a4d12" font-weight="700">MVPデモシナリオ（実演プラン）</text>
+
+  <rect x="80" y="150" width="460" height="700" rx="18" fill="#fff" stroke="#e7cda3" stroke-width="3"/>
+  <text x="120" y="220" font-family="Noto Sans CJK JP, sans-serif" font-size="34" fill="#8a5a00" font-weight="700">Demo 1</text>
+  <text x="120" y="270" font-family="Noto Sans CJK JP, sans-serif" font-size="30" fill="#5f4a2a">Yes/No 判定</text>
+  <text x="120" y="330" font-family="Noto Sans CJK JP, sans-serif" font-size="27" fill="#5f4a2a">入力: 危険行為の有無を判定</text>
+  <text x="120" y="380" font-family="Noto Sans CJK JP, sans-serif" font-size="27" fill="#5f4a2a">yes -> Slack + Device</text>
+  <text x="120" y="430" font-family="Noto Sans CJK JP, sans-serif" font-size="27" fill="#5f4a2a">no -> Slack only</text>
+
+  <rect x="120" y="500" width="380" height="300" rx="12" fill="#f9f2e6"/>
+  <text x="145" y="560" font-family="Noto Sans CJK JP, sans-serif" font-size="25" fill="#6a4a1d">見せ場</text>
+  <text x="145" y="605" font-family="Noto Sans CJK JP, sans-serif" font-size="24" fill="#6a4a1d">- 判定に応じた外部動作分岐</text>
+  <text x="145" y="645" font-family="Noto Sans CJK JP, sans-serif" font-size="24" fill="#6a4a1d">- WebUIと通知の同時可視化</text>
+  <text x="145" y="685" font-family="Noto Sans CJK JP, sans-serif" font-size="24" fill="#6a4a1d">- MVPの価値が最も伝わる</text>
+
+  <rect x="570" y="150" width="460" height="700" rx="18" fill="#fff" stroke="#e7cda3" stroke-width="3"/>
+  <text x="610" y="220" font-family="Noto Sans CJK JP, sans-serif" font-size="34" fill="#8a5a00" font-weight="700">Demo 2</text>
+  <text x="610" y="270" font-family="Noto Sans CJK JP, sans-serif" font-size="30" fill="#5f4a2a">Keyword 判定</text>
+  <text x="610" y="330" font-family="Noto Sans CJK JP, sans-serif" font-size="27" fill="#5f4a2a">ALERT/WARNING/CAUTION</text>
+  <text x="610" y="380" font-family="Noto Sans CJK JP, sans-serif" font-size="27" fill="#5f4a2a">一致時に Slack通知</text>
+
+  <rect x="610" y="500" width="380" height="300" rx="12" fill="#f9f2e6"/>
+  <text x="635" y="560" font-family="Noto Sans CJK JP, sans-serif" font-size="25" fill="#6a4a1d">見せ場</text>
+  <text x="635" y="605" font-family="Noto Sans CJK JP, sans-serif" font-size="24" fill="#6a4a1d">- 非構造テキストでも検知</text>
+  <text x="635" y="645" font-family="Noto Sans CJK JP, sans-serif" font-size="24" fill="#6a4a1d">- 運用に近い実務的シナリオ</text>
+  <text x="635" y="685" font-family="Noto Sans CJK JP, sans-serif" font-size="24" fill="#6a4a1d">- ノイズを抑えた通知制御</text>
+
+  <rect x="1060" y="150" width="460" height="700" rx="18" fill="#fff" stroke="#e7cda3" stroke-width="3"/>
+  <text x="1100" y="220" font-family="Noto Sans CJK JP, sans-serif" font-size="34" fill="#8a5a00" font-weight="700">Demo 3</text>
+  <text x="1100" y="270" font-family="Noto Sans CJK JP, sans-serif" font-size="30" fill="#5f4a2a">risk_score 判定</text>
+  <text x="1100" y="330" font-family="Noto Sans CJK JP, sans-serif" font-size="27" fill="#5f4a2a">閾値以上で通知</text>
+  <text x="1100" y="380" font-family="Noto Sans CJK JP, sans-serif" font-size="27" fill="#5f4a2a">（修正後に実施推奨）</text>
+
+  <rect x="1100" y="500" width="380" height="300" rx="12" fill="#f9f2e6"/>
+  <text x="1125" y="560" font-family="Noto Sans CJK JP, sans-serif" font-size="25" fill="#6a4a1d">見せ場</text>
+  <text x="1125" y="605" font-family="Noto Sans CJK JP, sans-serif" font-size="24" fill="#6a4a1d">- 構造化出力運用の有効性</text>
+  <text x="1125" y="645" font-family="Noto Sans CJK JP, sans-serif" font-size="24" fill="#6a4a1d">- 閾値チューニング議論が可能</text>
+  <text x="1125" y="685" font-family="Noto Sans CJK JP, sans-serif" font-size="24" fill="#6a4a1d">- 次フェーズへ繋がる導線</text>
+</svg>

--- a/mvp_demo_svgs/slide06_roadmap.svg
+++ b/mvp_demo_svgs/slide06_roadmap.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900">
+  <rect width="1600" height="900" fill="#f7fff7"/>
+  <text x="60" y="90" font-family="Noto Sans CJK JP, sans-serif" font-size="48" fill="#1f5f2b" font-weight="700">ロードマップと次アクション（MVP以降）</text>
+
+  <line x1="170" y1="220" x2="170" y2="780" stroke="#6da877" stroke-width="8"/>
+
+  <circle cx="170" cy="250" r="22" fill="#2e7d32"/>
+  <rect x="240" y="200" width="1290" height="110" rx="14" fill="#e2f3e5" stroke="#9bcc9f" stroke-width="2"/>
+  <text x="280" y="248" font-family="Noto Sans CJK JP, sans-serif" font-size="31" fill="#22592a" font-weight="700">Phase 1: MVP安定化（今ここ）</text>
+  <text x="280" y="288" font-family="Noto Sans CJK JP, sans-serif" font-size="26" fill="#2a5f31">risk_score判定の整合修正 / integration test安定化 / デモ運用手順の固定化</text>
+
+  <circle cx="170" cy="380" r="22" fill="#4b9b52"/>
+  <rect x="240" y="330" width="1290" height="110" rx="14" fill="#ecf8ee" stroke="#a7d7ad" stroke-width="2"/>
+  <text x="280" y="378" font-family="Noto Sans CJK JP, sans-serif" font-size="31" fill="#22592a" font-weight="700">Phase 2: payload/ルール高度化</text>
+  <text x="280" y="418" font-family="Noto Sans CJK JP, sans-serif" font-size="26" fill="#2a5f31">JSON運用強化、labels条件、重複通知抑制、監査ログ（event_id/rule_id/action_result）</text>
+
+  <circle cx="170" cy="510" r="22" fill="#6ab070"/>
+  <rect x="240" y="460" width="1290" height="110" rx="14" fill="#f2fbf3" stroke="#b8e1bd" stroke-width="2"/>
+  <text x="280" y="508" font-family="Noto Sans CJK JP, sans-serif" font-size="31" fill="#22592a" font-weight="700">Phase 3: 外部連携拡張</text>
+  <text x="280" y="548" font-family="Noto Sans CJK JP, sans-serif" font-size="26" fill="#2a5f31">ActionAdapter抽象化、MQTT/Teams/LINE、運用設定のノーコード化</text>
+
+  <circle cx="170" cy="640" r="22" fill="#89c18e"/>
+  <rect x="240" y="590" width="1290" height="150" rx="14" fill="#f8fdf8" stroke="#c8e8cc" stroke-width="2"/>
+  <text x="280" y="638" font-family="Noto Sans CJK JP, sans-serif" font-size="31" fill="#22592a" font-weight="700">将来: Physical AI / Embodied AI連携</text>
+  <text x="280" y="678" font-family="Noto Sans CJK JP, sans-serif" font-size="26" fill="#2a5f31">ROS2ブリッジ、ロボット制御ノード連携、デジタルツイン統合判定</text>
+  <text x="280" y="718" font-family="Noto Sans CJK JP, sans-serif" font-size="26" fill="#2a5f31">監視系デモから、行動オーケストレーション基盤へ段階拡張</text>
+
+  <text x="60" y="840" font-family="Noto Sans CJK JP, sans-serif" font-size="26" fill="#2d5d33">Reference: docs/development/action-orchestration-roadmap-ja.md</text>
+</svg>


### PR DESCRIPTION
  ## 概要
  MVPデモ説明用ドキュメントと図版を追加。

  ## 目的

  ## 変更内容
  - `MVP_DEMO_EXPLANATORY_DOC.md` を追加
  - `mvp_demo_svgs/` を追加

  ## 影響範囲
  - ドキュメントのみ（実装コードへの影響なし）

  ## 確認内容
  - 文書と図版の対応関係を確認
  - デモフロー説明として読める構成になっていることを確認

  ## 補足
  - 実装仕様変更は含まない