### PR TITLE
test: e2e live vlm to action webhook smoke

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -35,6 +35,7 @@ This directory contains documentation for developers working on the project.
 - **`../../tests/README.md`** - Testing infrastructure and organization
 - **`../../tests/e2e/README.md`** - End-to-end testing with Playwright
 - **`../../CONTRIBUTING.md`** - Contribution guidelines
+- **`e2e-live-vlm-to-action-webhook-smoke-ja.md`** - E2E smoke checks for action-webhook flow
 
 ## Development Workflow
 
@@ -44,4 +45,3 @@ This directory contains documentation for developers working on the project.
 4. **Profile if needed**: `./scripts/profile_code.sh component`
 
 See `testing-quickstart.md` for more details.
-

--- a/docs/development/e2e-live-vlm-to-action-webhook-smoke-ja.md
+++ b/docs/development/e2e-live-vlm-to-action-webhook-smoke-ja.md
@@ -1,0 +1,70 @@
+# E2Eスモーク手順: live-vlm-webui -> action-webhook
+
+## 目的
+- デモ前の最終確認として、`action-webhook` の受信・判定動作を短時間で検証する。
+- `yes/no`, `keyword`, `risk_score` の3系統ルールが想定どおり動作することを確認する。
+
+## この手順で確認できること
+- `action-webhook` コンテナ起動
+- `/healthz` 応答
+- `/events` に対するルール判定結果（`matched_rule_ids`, `actions`）
+
+## この手順で確認しないこと
+- カメラ入力からの実推論結果（WebRTC/RTSP経由）
+- 実Slack通知・実機器制御の到達
+
+上記は本手順の後に、手動スモークで確認する。
+
+## 前提
+- Docker / Docker Compose が利用可能
+- リポジトリルート: `live-vlm-webui/`
+
+## 実行コマンド
+```bash
+cd live-vlm-webui
+bash scripts/run_e2e_live_vlm_action_webhook_smoke.sh
+```
+
+## 期待結果
+- 最後に `SUCCESS: action-webhook E2E smoke checks passed.` が表示される
+- 実行中に以下3ケースが `OK` になる
+  - `rule_yes` + `slack,device`
+  - `rule_keyword_alert` + `slack`
+  - `rule_risk_high` + `slack`
+
+## オプション
+- `live-vlm-webui` も同時起動:
+```bash
+START_LIVE_VLM=1 bash scripts/run_e2e_live_vlm_action_webhook_smoke.sh
+```
+
+- action-webhook URLを変更:
+```bash
+ACTION_WEBHOOK_URL=http://127.0.0.1:8081 bash scripts/run_e2e_live_vlm_action_webhook_smoke.sh
+```
+
+- composeファイルを変更:
+```bash
+COMPOSE_FILE=docker/docker-compose.override.yml bash scripts/run_e2e_live_vlm_action_webhook_smoke.sh
+```
+
+## 実Slack/実機器の手動確認
+1. `.env` へ `SLACK_WEBHOOK_URL` と `DEVICE_ENDPOINT_URL` を設定
+2. `action-webhook` を再起動
+3. `curl` で `yes` / `keyword` / `risk_score` payload を送信
+4. Slack着信、機器動作を確認
+
+参考: `docs/development/action-webhook-manual-test-ja.md`
+
+## 失敗時の切り分け
+1. `healthz` がNG
+```bash
+docker compose -f docker/docker-compose.override.yml logs --tail=200 action-webhook
+```
+2. `/events` で期待ルールに一致しない
+- `ACTION_RULES_ENABLED=1` か確認
+- `ACTION_RULES_FILE=/app/rule_configs/rules.yaml` か確認
+3. 期待アクションが出ない
+- ルール定義: `services/action-webhook/rule_configs/rules.yaml`
+- 評価ロジック: `services/action-webhook/rules.py`
+

--- a/docs/development/e2e-live-vlm-to-action-webhook-smoke-ja.md
+++ b/docs/development/e2e-live-vlm-to-action-webhook-smoke-ja.md
@@ -48,6 +48,22 @@ ACTION_WEBHOOK_URL=http://127.0.0.1:8081 bash scripts/run_e2e_live_vlm_action_we
 COMPOSE_FILE=docker/docker-compose.override.yml bash scripts/run_e2e_live_vlm_action_webhook_smoke.sh
 ```
 
+### オプションの意図と挙動
+1. `START_LIVE_VLM=1`
+- 目的: `action-webhook` 単体確認に加えて、`live-vlm-webui` コンテナの起動疎通も同時に確認する。
+- 変化: スクリプト内で `live-vlm-webui` の `docker compose up` を追加実行する。
+- 注意: このオプションを有効にしても、カメラ入力からの実推論まで自動検証するわけではない。
+
+2. `ACTION_WEBHOOK_URL=...`
+- 目的: `action-webhook` の接続先を切り替える（別ホスト、ポート変更、リバースプロキシ配下など）。
+- 変化: `healthz` と `/events` の送信先URLが指定値に変わる。
+- 想定例: `http://127.0.0.1:8081`、`http://action-webhook:8081`（同一ネットワーク内）。
+
+3. `COMPOSE_FILE=...`
+- 目的: 使用する compose 定義を切り替える（環境別の定義、実験用定義）。
+- 変化: スクリプトが `docker compose -f <指定ファイル>` でサービスを起動する。
+- 想定例: 標準の `docker/docker-compose.override.yml` 以外の compose ファイル検証。
+
 ## 実Slack/実機器の手動確認
 1. `.env` へ `SLACK_WEBHOOK_URL` と `DEVICE_ENDPOINT_URL` を設定
 2. `action-webhook` を再起動
@@ -67,4 +83,3 @@ docker compose -f docker/docker-compose.override.yml logs --tail=200 action-webh
 3. 期待アクションが出ない
 - ルール定義: `services/action-webhook/rule_configs/rules.yaml`
 - 評価ロジック: `services/action-webhook/rules.py`
-

--- a/scripts/run_e2e_live_vlm_action_webhook_smoke.sh
+++ b/scripts/run_e2e_live_vlm_action_webhook_smoke.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# E2E smoke for action-webhook path.
+# - Starts action-webhook container
+# - Sends representative payloads to /events
+# - Verifies matched_rule_ids/actions in response
+#
+# NOTE:
+# This script validates receiver behavior with synthetic payloads.
+# For full camera/WebRTC inference flow, see the companion doc.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="${COMPOSE_FILE:-docker/docker-compose.override.yml}"
+ACTION_WEBHOOK_URL="${ACTION_WEBHOOK_URL:-http://localhost:8081}"
+START_LIVE_VLM="${START_LIVE_VLM:-0}" # Set 1 to also start live-vlm-webui.
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "ERROR: required command not found: $1" >&2
+    exit 1
+  }
+}
+
+wait_healthz() {
+  local url="$1"
+  local retries=40
+  local i
+  for i in $(seq 1 "$retries"); do
+    if curl -fsS "$url/healthz" >/dev/null 2>&1; then
+      echo "healthz OK: $url"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "ERROR: healthz check failed: $url" >&2
+  return 1
+}
+
+assert_event_response() {
+  local response_json="$1"
+  local expected_rule="$2"
+  local expected_actions_csv="$3"
+
+  python3 - "$response_json" "$expected_rule" "$expected_actions_csv" <<'PY'
+import json
+import sys
+
+body = json.loads(sys.argv[1])
+expected_rule = sys.argv[2]
+expected_actions = [x for x in sys.argv[3].split(",") if x]
+
+if body.get("status") != "accepted":
+    raise SystemExit(f"status is not accepted: {body}")
+
+rules = body.get("matched_rule_ids", [])
+if expected_rule and expected_rule not in rules:
+    raise SystemExit(f"expected rule not found: {expected_rule}, got={rules}")
+
+actions = body.get("actions", [])
+for action in expected_actions:
+    if action not in actions:
+        raise SystemExit(f"expected action not found: {action}, got={actions}")
+
+print(f"OK: rules={rules}, actions={actions}")
+PY
+}
+
+post_event() {
+  local payload="$1"
+  curl -fsS -X POST "$ACTION_WEBHOOK_URL/events" \
+    -H "Content-Type: application/json" \
+    -d "$payload"
+}
+
+main() {
+  require_cmd docker
+  require_cmd curl
+  require_cmd python3
+
+  cd "$ROOT_DIR"
+
+  if [[ ! -f "$COMPOSE_FILE" ]]; then
+    echo "ERROR: compose file not found: $COMPOSE_FILE" >&2
+    exit 1
+  fi
+
+  echo "[1/5] Starting action-webhook..."
+  ACTION_RULES_ENABLED=1 \
+  ACTION_RULES_FILE=/app/rule_configs/rules.yaml \
+  SLACK_WEBHOOK_URL= \
+  DEVICE_ENDPOINT_URL= \
+  DEVICE_TIMEOUT_SEC=1 \
+  RISK_THRESHOLD=0.75 \
+  docker compose -f "$COMPOSE_FILE" up -d --build action-webhook
+
+  if [[ "$START_LIVE_VLM" == "1" ]]; then
+    echo "[optional] Starting live-vlm-webui..."
+    docker compose -f "$COMPOSE_FILE" up -d --build --no-deps live-vlm-webui
+  fi
+
+  echo "[2/5] Waiting for healthz..."
+  wait_healthz "$ACTION_WEBHOOK_URL"
+
+  echo "[3/5] yes/no scenario"
+  resp="$(post_event '{
+    "event_id":"smoke-yes-001",
+    "event_type":"vlm_inference_result",
+    "mode":"single",
+    "text":"normal",
+    "answer":"yes"
+  }')"
+  assert_event_response "$resp" "rule_yes" "slack,device"
+
+  echo "[4/5] keyword scenario"
+  resp="$(post_event '{
+    "event_id":"smoke-keyword-001",
+    "event_type":"vlm_inference_result",
+    "mode":"single",
+    "text":"WARNING: smoke near panel"
+  }')"
+  assert_event_response "$resp" "rule_keyword_alert" "slack"
+
+  echo "[5/5] risk_score scenario"
+  resp="$(post_event '{
+    "event_id":"smoke-risk-001",
+    "event_type":"vlm_inference_result",
+    "mode":"single",
+    "text":"normal",
+    "risk_score":0.91
+  }')"
+  assert_event_response "$resp" "rule_risk_high" "slack"
+
+  echo "SUCCESS: action-webhook E2E smoke checks passed."
+  echo "Tip: docker compose -f $COMPOSE_FILE logs --tail=100 action-webhook"
+}
+
+main "$@"
+


### PR DESCRIPTION
  ## 概要
  `live-vlm-webui -> action-webhook` のE2E(End-to-End)スモーク確認を、再現可能なスクリプトと手順ドキュメントとして追加。

  ## 目的
  - デモ前に短時間で「受信・判定フロー」が正常か確認できるようにする
  - `yes/no`、`keyword`、`risk_score` の3系統ルールを通しで検証できるようにする

  ## 変更内容
  - 追加: `scripts/run_e2e_live_vlm_action_webhook_smoke.sh`
    - `action-webhook` 起動
    - `/healthz` 確認
    - `/events` に3ケース送信
    - `matched_rule_ids` / `actions` を自動検証
  - 追加: `docs/development/e2e-live-vlm-to-action-webhook-smoke-ja.md`
    - 実行手順、期待結果、切り分け手順
    - オプション環境変数（`START_LIVE_VLM`, `ACTION_WEBHOOK_URL`, `COMPOSE_FILE`）の意図と挙動
  - 更新: `docs/development/README.md`
    - 上記手順ドキュメントへのリンク追加

  ## 実行確認（ローカル）
  実行コマンド:
  ```bash
  bash scripts/run_e2e_live_vlm_action_webhook_smoke.sh

  実行結果（要約）:

  - healthz OK
  - yes/no scenario: rule_yes + slack,device -> OK
  - keyword scenario: rule_keyword_alert + slack -> OK
  - risk_score scenario: rule_risk_high + slack -> OK
  - SUCCESS: action-webhook E2E smoke checks passed.

  ## 影響範囲

  - テスト/ドキュメント追加のみ
  - アプリ本体ロジックの変更なし

  ## 補足

  - 本PRのスモークは action-webhook 受信〜判定フローの確認が対象
  - カメラ入力からの実推論フロー全体は別途手動確認が必要
